### PR TITLE
fix: items must be a schema (and add prefixItems)

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -75,7 +75,8 @@ type IntegerSchema = {
 
 type ArraySchema = {
   type: "array",
-  items: SchemaObject | SchemaObject[],
+  items?: SchemaObject,
+  prefixItems?: SchemaObject[],
   minItems?: number,
   maxItems?: number,
   uniqueItems?: boolean,


### PR DESCRIPTION
This was changed in JSON Schema Specification Draft 2020-12 (which is the version of JSON Schema used by OpenAPI 3.1). https://json-schema.org/draft/2020-12/json-schema-core#name-changelog:

> Array-value "items" functionality is now "prefixItems"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced array schema support by distinguishing between single-item schemas and positional item schemas, offering greater flexibility when defining arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->